### PR TITLE
Fix UI review issues: accessibility, HIG compliance, deduplication

### DIFF
--- a/DailyTracker/ViewModels/FriendsViewModel.swift
+++ b/DailyTracker/ViewModels/FriendsViewModel.swift
@@ -2,6 +2,7 @@ import Observation
 import Foundation
 import Supabase
 
+@MainActor
 @Observable
 final class FriendsViewModel {
     var profile: UserProfile? = nil
@@ -152,6 +153,19 @@ final class FriendsViewModel {
             await fetchFriends()
         } catch {
             print("[Friends] accept error: \(error)")
+        }
+    }
+
+    func cancelFriendRequest(friendshipId: UUID) async {
+        do {
+            try await client
+                .from("friendships")
+                .delete()
+                .eq("id", value: friendshipId.uuidString)
+                .execute()
+            await fetchFriends()
+        } catch {
+            print("[Friends] cancel request error: \(error)")
         }
     }
 

--- a/DailyTracker/Views/Calendar/CalendarGridView.swift
+++ b/DailyTracker/Views/Calendar/CalendarGridView.swift
@@ -1,0 +1,103 @@
+import SwiftUI
+
+/// Shared calendar grid used by both CalendarView (own data) and FriendCalendarView.
+/// Provides month navigation, weekday header, and day grid layout.
+/// The caller supplies the cell view for each date string via the `cell` closure.
+struct CalendarGridView<Cell: View>: View {
+    @Binding var currentMonth: Date
+    @ViewBuilder let cell: (String) -> Cell
+
+    private let columns = Array(repeating: GridItem(.flexible(), spacing: 6), count: 7)
+    private let weekdaySymbols = ["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"]
+
+    var body: some View {
+        VStack(spacing: 0) {
+            monthNavigator
+                .padding(.horizontal)
+                .padding(.vertical, 8)
+
+            Divider()
+
+            weekdayHeader
+                .padding(.horizontal)
+                .padding(.vertical, 6)
+
+            Divider()
+
+            ScrollView {
+                LazyVGrid(columns: columns, spacing: 6) {
+                    ForEach(Array(calendarDays.enumerated()), id: \.offset) { _, dayString in
+                        if dayString.isEmpty {
+                            Color.clear
+                                .frame(maxWidth: .infinity)
+                                .aspectRatio(1, contentMode: .fit)
+                        } else {
+                            cell(dayString)
+                        }
+                    }
+                }
+                .padding()
+            }
+        }
+    }
+
+    private var monthNavigator: some View {
+        HStack {
+            Button {
+                withAnimation(.easeInOut(duration: 0.25)) {
+                    currentMonth = Calendar.current.date(byAdding: .month, value: -1, to: currentMonth) ?? currentMonth
+                }
+            } label: {
+                Image(systemName: "chevron.left")
+                    .fontWeight(.semibold)
+                    .frame(width: 44, height: 44)
+            }
+            .accessibilityLabel("Previous month")
+
+            Spacer()
+
+            Text(currentMonth, format: .dateTime.month(.wide).year())
+                .font(.title2.weight(.bold))
+
+            Spacer()
+
+            Button {
+                withAnimation(.easeInOut(duration: 0.25)) {
+                    currentMonth = Calendar.current.date(byAdding: .month, value: 1, to: currentMonth) ?? currentMonth
+                }
+            } label: {
+                Image(systemName: "chevron.right")
+                    .fontWeight(.semibold)
+                    .frame(width: 44, height: 44)
+            }
+            .accessibilityLabel("Next month")
+        }
+    }
+
+    private var weekdayHeader: some View {
+        LazyVGrid(columns: columns, spacing: 6) {
+            ForEach(Array(weekdaySymbols.enumerated()), id: \.offset) { _, symbol in
+                Text(symbol)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity)
+            }
+        }
+    }
+
+    var calendarDays: [String] {
+        let calendar = Calendar.current
+        guard
+            let monthStart = calendar.date(from: calendar.dateComponents([.year, .month], from: currentMonth)),
+            let range = calendar.range(of: .day, in: .month, for: monthStart)
+        else { return [] }
+
+        let firstWeekday = calendar.component(.weekday, from: monthStart) - 1
+        var days: [String] = Array(repeating: "", count: firstWeekday)
+        for day in range {
+            guard let date = calendar.date(byAdding: .day, value: day - 1, to: monthStart) else { continue }
+            days.append(DateFormatter.dayFormatter.string(from: date))
+        }
+        return days
+    }
+}

--- a/DailyTracker/Views/Calendar/CalendarView.swift
+++ b/DailyTracker/Views/Calendar/CalendarView.swift
@@ -7,42 +7,14 @@ struct CalendarView: View {
     @State private var currentMonth: Date = Date()
     @State private var selectedDayString: String? = nil
 
-    private let columns = Array(repeating: GridItem(.flexible(), spacing: 6), count: 7)
-    private let weekdaySymbols = ["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"]
-
     var body: some View {
         NavigationStack {
-            VStack(spacing: 0) {
-                monthNavigator
-                    .padding(.horizontal)
-                    .padding(.vertical, 8)
-
-                Divider()
-
-                weekdayHeader
-                    .padding(.horizontal)
-                    .padding(.vertical, 6)
-
-                Divider()
-
-                ScrollView {
-                    LazyVGrid(columns: columns, spacing: 6) {
-                        ForEach(Array(calendarDays.enumerated()), id: \.offset) { _, dayString in
-                            if dayString.isEmpty {
-                                Color.clear
-                                .frame(maxWidth: .infinity)
-                                .aspectRatio(1, contentMode: .fit)
-                            } else {
-                                DayCell(
-                                    dateString: dayString,
-                                    record: record(for: dayString)
-                                ) {
-                                    selectedDayString = dayString
-                                }
-                            }
-                        }
-                    }
-                    .padding()
+            CalendarGridView(currentMonth: $currentMonth) { dayString in
+                DayCell(
+                    dateString: dayString,
+                    record: record(for: dayString)
+                ) {
+                    selectedDayString = dayString
                 }
             }
             .navigationTitle("Calendar")
@@ -53,76 +25,6 @@ struct CalendarView: View {
                 )
             }
         }
-    }
-
-    // MARK: - Header Views
-
-    private var monthNavigator: some View {
-        HStack {
-            Button {
-                withAnimation(.easeInOut(duration: 0.25)) {
-                    currentMonth = Calendar.current.date(
-                        byAdding: .month, value: -1, to: currentMonth
-                    ) ?? currentMonth
-                }
-            } label: {
-                Image(systemName: "chevron.left")
-                    .fontWeight(.semibold)
-                    .frame(width: 44, height: 44)
-            }
-
-            Spacer()
-
-            Text(currentMonth, format: .dateTime.month(.wide).year())
-                .font(.title2.weight(.bold))
-
-            Spacer()
-
-            Button {
-                withAnimation(.easeInOut(duration: 0.25)) {
-                    currentMonth = Calendar.current.date(
-                        byAdding: .month, value: 1, to: currentMonth
-                    ) ?? currentMonth
-                }
-            } label: {
-                Image(systemName: "chevron.right")
-                    .fontWeight(.semibold)
-                    .frame(width: 44, height: 44)
-            }
-        }
-    }
-
-    private var weekdayHeader: some View {
-        LazyVGrid(columns: columns, spacing: 6) {
-            ForEach(Array(weekdaySymbols.enumerated()), id: \.offset) { _, symbol in
-                Text(symbol)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .frame(maxWidth: .infinity)
-            }
-        }
-    }
-
-    // MARK: - Calendar Logic
-
-    private var calendarDays: [String] {
-        let calendar = Calendar.current
-        guard
-            let monthStart = calendar.date(
-                from: calendar.dateComponents([.year, .month], from: currentMonth)
-            ),
-            let range = calendar.range(of: .day, in: .month, for: monthStart)
-        else { return [] }
-
-        let firstWeekday = calendar.component(.weekday, from: monthStart) - 1
-        var days: [String] = Array(repeating: "", count: firstWeekday)
-
-        for day in range {
-            guard let date = calendar.date(byAdding: .day, value: day - 1, to: monthStart) else { continue }
-            days.append(DateFormatter.dayFormatter.string(from: date))
-        }
-
-        return days
     }
 
     private func record(for dateString: String) -> DayRecord? {

--- a/DailyTracker/Views/Calendar/DayCell.swift
+++ b/DailyTracker/Views/Calendar/DayCell.swift
@@ -42,11 +42,16 @@ struct DayCell: View {
                         .fill(Color.green.opacity(isToday ? 1.0 : 0.28))
                         .padding(2)
                 case .partial:
-                    partialCircle
-                        .padding(2)
+                    HStack(spacing: 0) {
+                        Color.orange.opacity(isToday ? 1.0 : 0.35)
+                        Color.gray.opacity(isToday ? 0.4 : 0.14)
+                    }
+                    .clipShape(Circle())
+                    .padding(2)
                 case .missed:
+                    // Stroke-only ring so colorblind users can distinguish from filled complete
                     Circle()
-                        .fill(Color.red.opacity(isToday ? 1.0 : 0.28))
+                        .stroke(Color.red.opacity(isToday ? 1.0 : 0.5), lineWidth: 1.5)
                         .padding(2)
                 case .none:
                     if isToday {
@@ -67,19 +72,25 @@ struct DayCell: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-    }
-
-    // Left half orange, right half gray — indicates partial completion
-    private var partialCircle: some View {
-        let opacity = isToday ? 1.0 : 0.35
-        return HStack(spacing: 0) {
-            Color.orange.opacity(opacity)
-            Color.gray.opacity(opacity * 0.4)
-        }
-        .clipShape(Circle())
+        .accessibilityLabel(accessibilityLabel)
     }
 
     private var textColor: Color {
-        isToday ? .white : .primary
+        // Missed uses stroke (no fill), so text stays primary regardless of today status
+        if dayCompletion == .missed { return .primary }
+        return isToday ? .white : .primary
+    }
+
+    private var accessibilityLabel: String {
+        guard
+            let date = DateFormatter.dayFormatter.date(from: dateString)
+        else { return dateString }
+        let dateLabel = date.formatted(.dateTime.month(.wide).day().year())
+        switch dayCompletion {
+        case .complete: return "\(dateLabel), all tasks complete"
+        case .partial:  return "\(dateLabel), partially complete"
+        case .missed:   return "\(dateLabel), no tasks completed"
+        case .none:     return dateLabel
+        }
     }
 }

--- a/DailyTracker/Views/Calendar/DaySummaryView.swift
+++ b/DailyTracker/Views/Calendar/DaySummaryView.swift
@@ -64,7 +64,7 @@ struct DaySummaryView: View {
                             }
                         }
                         Spacer()
-                        Text(percentLabel(record.completionRatio))
+                        Label(percentLabel(record.completionRatio), systemImage: statusIcon(record.completionRatio))
                             .font(.headline)
                             .foregroundStyle(statusColor(record.completionRatio))
                     }
@@ -187,5 +187,11 @@ struct DaySummaryView: View {
         if ratio == 1.0 { return .green }
         if ratio > 0 { return .yellow }
         return .red
+    }
+
+    private func statusIcon(_ ratio: Double) -> String {
+        if ratio == 1.0 { return "checkmark.circle.fill" }
+        if ratio > 0 { return "circle.lefthalf.filled" }
+        return "xmark.circle.fill"
     }
 }

--- a/DailyTracker/Views/Friends/FriendCalendarView.swift
+++ b/DailyTracker/Views/Friends/FriendCalendarView.swift
@@ -6,40 +6,25 @@ struct FriendCalendarView: View {
 
     @State private var currentMonth: Date = Date()
     @State private var records: [FriendDayRecord] = []
+    @State private var isLoading = false
     @State private var selectedDay: SelectedFriendDay? = nil
-
-    private let columns = Array(repeating: GridItem(.flexible(), spacing: 6), count: 7)
-    private let weekdaySymbols = ["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"]
 
     var body: some View {
         NavigationStack {
-            VStack(spacing: 0) {
-                monthNavigator
-                    .padding(.horizontal)
-                    .padding(.vertical, 8)
-                Divider()
-                weekdayHeader
-                    .padding(.horizontal)
-                    .padding(.vertical, 6)
-                Divider()
-                ScrollView {
-                    LazyVGrid(columns: columns, spacing: 6) {
-                        ForEach(Array(calendarDays.enumerated()), id: \.offset) { _, dayString in
-                            if dayString.isEmpty {
-                                Color.clear
-                                    .frame(maxWidth: .infinity)
-                                    .aspectRatio(1, contentMode: .fit)
-                            } else {
-                                let rec = record(for: dayString)
-                                FriendDayCell(dateString: dayString, record: rec) {
-                                    if let r = rec {
-                                        selectedDay = SelectedFriendDay(dateString: dayString, record: r)
-                                    }
-                                }
-                            }
+            ZStack {
+                CalendarGridView(currentMonth: $currentMonth) { dayString in
+                    let rec = record(for: dayString)
+                    FriendDayCell(dateString: dayString, record: rec) {
+                        if let r = rec {
+                            selectedDay = SelectedFriendDay(dateString: dayString, record: r)
                         }
                     }
-                    .padding()
+                }
+
+                if isLoading {
+                    ProgressView()
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                        .background(.ultraThinMaterial)
                 }
             }
             .navigationTitle(friend.displayName)
@@ -48,54 +33,11 @@ struct FriendCalendarView: View {
                 FriendDaySummary(dateString: day.dateString, record: day.record)
             }
             .task {
+                isLoading = true
                 records = await vm.fetchFriendCalendar(userId: friend.userId)
+                isLoading = false
             }
         }
-    }
-
-    private var monthNavigator: some View {
-        HStack {
-            Button {
-                withAnimation(.easeInOut(duration: 0.25)) {
-                    currentMonth = Calendar.current.date(byAdding: .month, value: -1, to: currentMonth) ?? currentMonth
-                }
-            } label: {
-                Image(systemName: "chevron.left").fontWeight(.semibold).frame(width: 44, height: 44)
-            }
-            Spacer()
-            Text(currentMonth, format: .dateTime.month(.wide).year()).font(.title2.weight(.bold))
-            Spacer()
-            Button {
-                withAnimation(.easeInOut(duration: 0.25)) {
-                    currentMonth = Calendar.current.date(byAdding: .month, value: 1, to: currentMonth) ?? currentMonth
-                }
-            } label: {
-                Image(systemName: "chevron.right").fontWeight(.semibold).frame(width: 44, height: 44)
-            }
-        }
-    }
-
-    private var weekdayHeader: some View {
-        LazyVGrid(columns: columns, spacing: 6) {
-            ForEach(Array(weekdaySymbols.enumerated()), id: \.offset) { _, symbol in
-                Text(symbol).font(.caption).foregroundStyle(.secondary).frame(maxWidth: .infinity)
-            }
-        }
-    }
-
-    private var calendarDays: [String] {
-        let calendar = Calendar.current
-        guard
-            let monthStart = calendar.date(from: calendar.dateComponents([.year, .month], from: currentMonth)),
-            let range = calendar.range(of: .day, in: .month, for: monthStart)
-        else { return [] }
-        let firstWeekday = calendar.component(.weekday, from: monthStart) - 1
-        var days: [String] = Array(repeating: "", count: firstWeekday)
-        for day in range {
-            guard let date = calendar.date(byAdding: .day, value: day - 1, to: monthStart) else { continue }
-            days.append(DateFormatter.dayFormatter.string(from: date))
-        }
-        return days
     }
 
     private func record(for dateString: String) -> FriendDayRecord? {
@@ -153,7 +95,7 @@ struct FriendDayCell: View {
                     .padding(2)
                 case .missed:
                     Circle()
-                        .fill(Color.red.opacity(isToday ? 1.0 : 0.28))
+                        .stroke(Color.red.opacity(isToday ? 1.0 : 0.5), lineWidth: 1.5)
                         .padding(2)
                 case .none:
                     if isToday {
@@ -162,7 +104,7 @@ struct FriendDayCell: View {
                 }
                 Text(dayNumber)
                     .font(.system(size: 15, weight: isToday ? .semibold : .regular))
-                    .foregroundStyle(isToday ? .white : .primary)
+                    .foregroundStyle(dayCompletion == .missed ? .primary : (isToday ? .white : .primary))
                     .minimumScaleFactor(0.6)
                     .lineLimit(1)
             }
@@ -171,6 +113,18 @@ struct FriendDayCell: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+        .accessibilityLabel(accessibilityLabel)
+    }
+
+    private var accessibilityLabel: String {
+        guard let date = DateFormatter.dayFormatter.date(from: dateString) else { return dateString }
+        let dateLabel = date.formatted(.dateTime.month(.wide).day().year())
+        switch dayCompletion {
+        case .complete: return "\(dateLabel), all tasks complete"
+        case .partial:  return "\(dateLabel), partially complete"
+        case .missed:   return "\(dateLabel), no tasks completed"
+        case .none:     return dateLabel
+        }
     }
 }
 
@@ -193,11 +147,20 @@ struct FriendDaySummary: View {
         return .red
     }
 
+    private var statusIcon: String {
+        if record.completionRatio == 1.0 { return "checkmark.circle.fill" }
+        if record.completionRatio > 0 { return "circle.lefthalf.filled" }
+        return "xmark.circle.fill"
+    }
+
     var body: some View {
         NavigationStack {
             VStack(spacing: 24) {
                 Spacer()
                 VStack(spacing: 8) {
+                    Image(systemName: statusIcon)
+                        .font(.system(size: 40))
+                        .foregroundStyle(statusColor)
                     Text("\(Int(record.completionRatio * 100))%")
                         .font(.system(size: 72, weight: .bold, design: .rounded))
                         .foregroundStyle(statusColor)
@@ -223,6 +186,6 @@ struct FriendDaySummary: View {
                 }
             }
         }
-        .presentationDetents([.height(280)])
+        .presentationDetents([.height(320)])
     }
 }

--- a/DailyTracker/Views/Friends/FriendsView.swift
+++ b/DailyTracker/Views/Friends/FriendsView.swift
@@ -161,11 +161,17 @@ struct FriendsView: View {
 
             ForEach(outgoing) { pending in
                 HStack {
-                    Text(pending.displayName)
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(pending.displayName)
+                        Text("Request sent")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
                     Spacer()
-                    Text("Pending")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
+                    Button("Cancel", role: .destructive) {
+                        Task { await vm.cancelFriendRequest(friendshipId: pending.friendshipId) }
+                    }
+                    .controlSize(.small)
                 }
             }
         }
@@ -210,7 +216,7 @@ struct FriendsView: View {
                             }
                         }
                     }
-                    .disabled(friendCodeInput.trimmingCharacters(in: .whitespaces).isEmpty)
+                    .disabled(friendCodeInput.trimmingCharacters(in: .whitespaces).count != 6)
                 }
             }
         }

--- a/DailyTracker/Views/Tasks/TaskRowView.swift
+++ b/DailyTracker/Views/Tasks/TaskRowView.swift
@@ -24,6 +24,12 @@ struct TaskRowView: View {
         return .secondary
     }
 
+    private var checkboxAccessibilityLabel: String {
+        if task.isCompleted { return "Completed: \(task.title). Tap to mark incomplete." }
+        if task.isPartial { return "Partial: \(task.title). Tap to mark complete." }
+        return "Incomplete: \(task.title). Tap to mark partial."
+    }
+
     var body: some View {
         Button(action: triggerAnimation) {
             HStack(spacing: 12) {
@@ -47,6 +53,7 @@ struct TaskRowView: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+        .accessibilityLabel(checkboxAccessibilityLabel)
     }
 
     // MARK: - Checkbox + Particles
@@ -84,23 +91,22 @@ struct TaskRowView: View {
     private func triggerAnimation() {
         onToggle()
 
-        // Scale pop
         checkBounce = true
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.35) {
-            checkBounce = false
-        }
-
-        // Particle burst
         particlesVisible = true
         withAnimation(.spring(response: 0.4, dampingFraction: 0.6)) {
             particleProgress = 1
         }
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.45) {
+
+        Task {
+            try? await Task.sleep(for: .milliseconds(350))
+            checkBounce = false
+
+            try? await Task.sleep(for: .milliseconds(100))
             withAnimation(.easeIn(duration: 0.2)) {
                 particleProgress = 0
             }
-        }
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.65) {
+
+            try? await Task.sleep(for: .milliseconds(200))
             particlesVisible = false
         }
     }

--- a/DailyTracker/Views/Tasks/TasksView.swift
+++ b/DailyTracker/Views/Tasks/TasksView.swift
@@ -79,13 +79,14 @@ struct TasksView: View {
                         EditButton()
                     }
                 }
-                ToolbarItem(placement: .topBarLeading) {
+                ToolbarItem(placement: .topBarTrailing) {
                     Button {
                         showingFriends = true
                     } label: {
                         Image(systemName: "person.circle.fill")
                             .font(.title3)
                     }
+                    .accessibilityLabel("Friends")
                 }
                 ToolbarItem(placement: .topBarTrailing) {
                     Button {
@@ -93,6 +94,7 @@ struct TasksView: View {
                     } label: {
                         Image(systemName: "plus")
                     }
+                    .accessibilityLabel("Add task")
                 }
             }
             .sheet(isPresented: $showingFriends) {

--- a/supabase/migrations/20260402224034_add_friendship_delete_policy.sql
+++ b/supabase/migrations/20260402224034_add_friendship_delete_policy.sql
@@ -1,0 +1,4 @@
+-- Allow the requester to cancel (delete) their own pending friendship request
+create policy "Requester can delete own friendship requests"
+  on public.friendships for delete
+  using (auth.uid() = requester_id);


### PR DESCRIPTION
Closes #4

## Changes

### HIG Compliance
- Friends button moved from `topBarLeading` to `topBarTrailing` — leading is for Edit/Back only

### Colorblind Accessibility
- Missed days now use a **stroke ring** instead of a filled red circle — shape now differentiates complete (solid fill) vs missed (outline) vs partial (split fill) without relying on color alone
- Status summary now shows an icon (checkmark / half-circle / xmark) alongside the percentage

### Accessibility Labels
- Friends button: "Friends"
- Add task button: "Add task"
- Month navigation: "Previous month" / "Next month"
- Day cells: "\(date), all tasks complete / partially complete / no tasks completed"
- Task row buttons: describes current state and what tap will do

### Code Deduplication
- `CalendarGridView` extracted as a shared component used by both `CalendarView` and `FriendCalendarView` — month nav, weekday header, grid logic no longer duplicated

### Loading State
- `FriendCalendarView` shows `ProgressView` overlay while fetching friend's calendar data

### Friends UX
- Outgoing pending requests show a **Cancel** button to withdraw the request
- Send button in Add Friend sheet requires exactly 6 characters before enabling

### Animation
- `TaskRowView` animation timing replaced with `Task` + `Task.sleep(for:)` instead of three chained `DispatchQueue.main.asyncAfter` calls

### DB
- New migration adds `DELETE` policy on `friendships` so requesters can cancel their own pending requests

## Test plan
- [ ] Run `supabase db push` to apply migration 224034
- [ ] Friends button appears top-right on Tasks screen
- [ ] Missed days show as ring outline, complete as solid green, partial as split
- [ ] VoiceOver reads day cell dates and completion status
- [ ] Friend calendar shows spinner while loading
- [ ] Can cancel an outgoing friend request
- [ ] Send button stays disabled until 6 chars entered

🤖 Generated with [Claude Code](https://claude.com/claude-code)