### PR TITLE
Add progress ring and lock screen widget variants to TaskCountWidget

### DIFF
--- a/DailyTrackerWidget/TaskCountWidget.swift
+++ b/DailyTrackerWidget/TaskCountWidget.swift
@@ -59,33 +59,109 @@ struct TaskCountProvider: TimelineProvider {
 struct TaskCountWidgetView: View {
     let entry: TaskCountEntry
 
+    @Environment(\.widgetFamily) private var widgetFamily
+
     var body: some View {
-        VStack(spacing: 4) {
-            if entry.total == 0 {
-                Image(systemName: "checkmark.circle")
-                    .font(.system(size: 32, weight: .light))
-                    .foregroundStyle(.secondary)
-                Text("No tasks")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            } else if entry.remaining == 0 {
-                Image(systemName: "checkmark.circle.fill")
-                    .font(.system(size: 32))
-                    .foregroundStyle(.green)
-                Text("All done!")
-                    .font(.caption.bold())
-                    .foregroundStyle(.green)
-            } else {
-                Text("\(entry.remaining)")
-                    .font(.system(size: 48, weight: .bold, design: .rounded))
-                    .foregroundStyle(.primary)
-                    .minimumScaleFactor(0.6)
-                Text(entry.remaining == 1 ? "task left" : "tasks left")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+        switch widgetFamily {
+        case .accessoryCircular:
+            accessoryCircularBody
+        case .accessoryRectangular:
+            accessoryRectangularBody
+        default:
+            systemSmallBody
+        }
+    }
+
+    private var ringColor: Color {
+        if entry.total == 0 { return .secondary }
+        if entry.remaining == 0 { return .green }
+        return .blue
+    }
+
+    // MARK: systemSmall
+
+    private var systemSmallBody: some View {
+        ZStack {
+            Circle()
+                .stroke(Color.gray.opacity(0.2), style: StrokeStyle(lineWidth: 8, lineCap: .round))
+                .frame(width: 80, height: 80)
+            Circle()
+                .trim(from: 0, to: entry.ratio)
+                .stroke(ringColor, style: StrokeStyle(lineWidth: 8, lineCap: .round))
+                .frame(width: 80, height: 80)
+                .rotationEffect(.degrees(-90))
+            VStack(spacing: 4) {
+                if entry.total == 0 {
+                    Image(systemName: "checkmark.circle")
+                        .font(.system(size: 32, weight: .light))
+                        .foregroundStyle(.secondary)
+                    Text("No tasks")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                } else if entry.remaining == 0 {
+                    Image(systemName: "checkmark.circle.fill")
+                        .font(.system(size: 32))
+                        .foregroundStyle(.green)
+                    Text("All done!")
+                        .font(.caption.bold())
+                        .foregroundStyle(.green)
+                } else {
+                    Text("\(entry.remaining)")
+                        .font(.system(size: 48, weight: .bold, design: .rounded))
+                        .foregroundStyle(.primary)
+                        .minimumScaleFactor(0.6)
+                    Text(entry.remaining == 1 ? "task left" : "tasks left")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .containerBackground(.background, for: .widget)
+    }
+
+    // MARK: accessoryCircular
+
+    private var accessoryCircularBody: some View {
+        Gauge(value: entry.ratio, in: 0...1) {
+            EmptyView()
+        } currentValueLabel: {
+            if entry.total == 0 {
+                Image(systemName: "minus")
+                    .font(.caption.bold())
+            } else if entry.remaining == 0 {
+                Image(systemName: "checkmark")
+                    .font(.caption.bold())
+            } else {
+                Text("\(entry.remaining)")
+                    .font(.caption.bold())
+                    .minimumScaleFactor(0.6)
+            }
+        }
+        .gaugeStyle(.accessoryCircularCapacity)
+        .containerBackground(.background, for: .widget)
+    }
+
+    // MARK: accessoryRectangular
+
+    private var accessoryRectangularBody: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            if entry.total == 0 {
+                Label("No tasks", systemImage: "checkmark.circle")
+                    .font(.headline)
+                    .foregroundStyle(.secondary)
+            } else if entry.remaining == 0 {
+                Label("All done!", systemImage: "checkmark.circle.fill")
+                    .font(.headline)
+            } else {
+                Text("\(entry.remaining) \(entry.remaining == 1 ? "task left" : "tasks left")")
+                    .font(.headline)
+                    .minimumScaleFactor(0.8)
+            }
+            ProgressView(value: entry.ratio, total: 1.0)
+                .tint(ringColor)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
         .containerBackground(.background, for: .widget)
     }
 }
@@ -101,6 +177,6 @@ struct TaskCountWidget: Widget {
         }
         .configurationDisplayName("Tasks Remaining")
         .description("See how many tasks you have left today.")
-        .supportedFamilies([.systemSmall])
+        .supportedFamilies([.systemSmall, .accessoryCircular, .accessoryRectangular])
     }
 }


### PR DESCRIPTION
- Wrap systemSmall center content in a ZStack with a circular progress
  ring (Circle().trim) that fills based on task completion ratio
- Add accessoryCircular layout using Gauge/.accessoryCircularCapacity
  for a canonical lock screen arc widget
- Add accessoryRectangular layout with a headline label and linear
  ProgressView for the wide lock screen slot
- Route layouts via @Environment(\.widgetFamily) switch
- Extend supportedFamilies to [.systemSmall, .accessoryCircular, .accessoryRectangular]

https://claude.ai/code/session_0171gdYELc3rKgGUveZTVfWn