### PR TITLE
Fix past-day calendar showing another user's tasks

### DIFF
--- a/DailyTracker/ContentView.swift
+++ b/DailyTracker/ContentView.swift
@@ -1,18 +1,30 @@
 import SwiftUI
+import SwiftData
 
 struct ContentView: View {
+    let userId: String
+
+    @Environment(\.modelContext) private var modelContext
+    @Query(filter: #Predicate<DayRecord> { $0.userId == "" }) private var legacyRecords: [DayRecord]
+    @Query(filter: #Predicate<TaskItem> { $0.userId == "" }) private var legacyTasks: [TaskItem]
+
     var body: some View {
         TabView {
-            TasksView()
+            TasksView(userId: userId)
                 .tabItem {
                     Label("Tasks", systemImage: "checkmark.circle.fill")
                 }
 
-            CalendarView()
+            CalendarView(userId: userId)
                 .tabItem {
                     Label("Calendar", systemImage: "calendar")
                 }
-
+        }
+        .onChange(of: userId) { _, newId in
+            guard !newId.isEmpty else { return }
+            for record in legacyRecords { record.userId = newId }
+            for task in legacyTasks { task.userId = newId }
+            try? modelContext.save()
         }
     }
 }

--- a/DailyTracker/DailyTrackerApp.swift
+++ b/DailyTracker/DailyTrackerApp.swift
@@ -4,12 +4,16 @@ import SwiftData
 @main
 struct DailyTrackerApp: App {
     let sharedModelContainer: ModelContainer = SharedDataStore.makeContainer()
+    @State private var userId: String = ""
 
     var body: some Scene {
         WindowGroup {
-            ContentView()
+            ContentView(userId: userId)
                 .task {
                     await SupabaseManager.shared.signInIfNeeded()
+                    let resolvedId = SupabaseManager.shared.userId?.uuidString ?? ""
+                    SharedDataStore.sharedDefaults.set(resolvedId, forKey: "currentUserId")
+                    userId = resolvedId
                 }
         }
         .modelContainer(sharedModelContainer)

--- a/DailyTracker/SupabaseManager.swift
+++ b/DailyTracker/SupabaseManager.swift
@@ -47,9 +47,13 @@ final class SupabaseManager {
     }
 
     func deleteTask(id: UUID) async {
-        guard userId != nil else { return }
+        guard let userId else { return }
         do {
-            try await client.from("task_items").delete().eq("id", value: id.uuidString).execute()
+            try await client.from("task_items")
+                .delete()
+                .eq("id", value: id.uuidString)
+                .eq("user_id", value: userId.uuidString)
+                .execute()
         } catch {
             print("[Supabase] delete task error: \(error)")
         }

--- a/DailyTracker/Views/Calendar/CalendarView.swift
+++ b/DailyTracker/Views/Calendar/CalendarView.swift
@@ -4,8 +4,15 @@ import SwiftData
 struct CalendarView: View {
     @Query private var dayRecords: [DayRecord]
 
+    let userId: String
     @State private var currentMonth: Date = Date()
     @State private var selectedDayString: String? = nil
+
+    init(userId: String) {
+        self.userId = userId
+        let uid = userId
+        _dayRecords = Query(filter: #Predicate<DayRecord> { $0.userId == uid })
+    }
 
     var body: some View {
         NavigationStack {
@@ -21,7 +28,8 @@ struct CalendarView: View {
             .sheet(item: selectedDayBinding) { selected in
                 DaySummaryView(
                     dateString: selected.dateString,
-                    record: record(for: selected.dateString)
+                    record: record(for: selected.dateString),
+                    userId: userId
                 )
             }
         }

--- a/DailyTracker/Views/Calendar/DaySummaryView.swift
+++ b/DailyTracker/Views/Calendar/DaySummaryView.swift
@@ -4,11 +4,23 @@ import SwiftData
 struct DaySummaryView: View {
     let dateString: String
     let record: DayRecord?
+    let userId: String
 
     @Environment(\.dismiss) private var dismiss
     @Environment(\.modelContext) private var modelContext
-    @Query(sort: \TaskItem.orderIndex) private var taskItems: [TaskItem]
+    @Query private var taskItems: [TaskItem]
     @State private var createdRecord: DayRecord? = nil
+
+    init(dateString: String, record: DayRecord?, userId: String) {
+        self.dateString = dateString
+        self.record = record
+        self.userId = userId
+        let uid = userId
+        _taskItems = Query(
+            filter: #Predicate<TaskItem> { $0.userId == uid },
+            sort: \.orderIndex
+        )
+    }
 
     private var activeRecord: DayRecord? { record ?? createdRecord }
 
@@ -180,7 +192,8 @@ struct DaySummaryView: View {
         let newRecord = DayRecord(
             dateString: dateString,
             allTaskTitles: taskItems.map { $0.title },
-            completedTaskTitles: []
+            completedTaskTitles: [],
+            userId: userId
         )
         modelContext.insert(newRecord)
         createdRecord = newRecord

--- a/DailyTracker/Views/Calendar/DaySummaryView.swift
+++ b/DailyTracker/Views/Calendar/DaySummaryView.swift
@@ -183,8 +183,9 @@ struct DaySummaryView: View {
     }
 
     private func makeRecord() -> DayRecord {
+        let uid = userId
         if let existing = try? modelContext.fetch(
-            FetchDescriptor<DayRecord>(predicate: #Predicate { $0.dateString == dateString })
+            FetchDescriptor<DayRecord>(predicate: #Predicate { $0.dateString == dateString && $0.userId == uid })
         ).first {
             createdRecord = existing
             return existing

--- a/DailyTracker/Views/Tasks/TasksView.swift
+++ b/DailyTracker/Views/Tasks/TasksView.swift
@@ -5,10 +5,21 @@ import WidgetKit
 struct TasksView: View {
     @Environment(\.modelContext) private var modelContext
     @Environment(\.scenePhase) private var scenePhase
-    @Query(sort: \TaskItem.orderIndex) private var tasks: [TaskItem]
+    @Query private var tasks: [TaskItem]
     @Query private var dayRecords: [DayRecord]
 
+    let userId: String
     @State private var showingAddTask = false
+
+    init(userId: String) {
+        self.userId = userId
+        let uid = userId
+        _tasks = Query(
+            filter: #Predicate<TaskItem> { $0.userId == uid },
+            sort: \.orderIndex
+        )
+        _dayRecords = Query(filter: #Predicate<DayRecord> { $0.userId == uid })
+    }
     @State private var showCelebration = false
     @State private var taskToEdit: TaskItem? = nil
     @State private var showingFriends = false
@@ -183,7 +194,7 @@ struct TasksView: View {
     }
 
     private func addTask(title: String) {
-        let task = TaskItem(title: title, orderIndex: tasks.count)
+        let task = TaskItem(title: title, orderIndex: tasks.count, userId: userId)
         modelContext.insert(task)
         try? modelContext.save()
         saveRecord(from: tasks + [task])
@@ -227,7 +238,8 @@ struct TasksView: View {
                 dateString: today,
                 allTaskTitles: allTitles,
                 completedTaskTitles: completedTitles,
-                partiallyCompletedTaskTitles: partialTitles
+                partiallyCompletedTaskTitles: partialTitles,
+                userId: userId
             )
             modelContext.insert(record)
         }

--- a/DailyTracker/Views/Tasks/TasksView.swift
+++ b/DailyTracker/Views/Tasks/TasksView.swift
@@ -10,6 +10,9 @@ struct TasksView: View {
 
     let userId: String
     @State private var showingAddTask = false
+    @State private var showCelebration = false
+    @State private var taskToEdit: TaskItem? = nil
+    @State private var showingFriends = false
 
     init(userId: String) {
         self.userId = userId
@@ -20,9 +23,6 @@ struct TasksView: View {
         )
         _dayRecords = Query(filter: #Predicate<DayRecord> { $0.userId == uid })
     }
-    @State private var showCelebration = false
-    @State private var taskToEdit: TaskItem? = nil
-    @State private var showingFriends = false
 
     private var todayString: String { Date().dayString }
 

--- a/DailyTrackerWidget/ToggleTaskIntent.swift
+++ b/DailyTrackerWidget/ToggleTaskIntent.swift
@@ -17,11 +17,16 @@ struct ToggleTaskIntent: AppIntent {
     func perform() async throws -> some IntentResult {
         guard let id = UUID(uuidString: taskID) else { return .result() }
 
+        let currentUserId = SharedDataStore.sharedDefaults.string(forKey: "currentUserId") ?? ""
+
         let container = SharedDataStore.makeContainer()
         let context = ModelContext(container)
 
         let tasks = (try? context.fetch(
-            FetchDescriptor<TaskItem>(sortBy: [SortDescriptor(\.orderIndex)])
+            FetchDescriptor<TaskItem>(
+                predicate: #Predicate { $0.userId == currentUserId },
+                sortBy: [SortDescriptor(\.orderIndex)]
+            )
         )) ?? []
 
         guard let task = tasks.first(where: { $0.id == id }) else { return .result() }
@@ -41,7 +46,11 @@ struct ToggleTaskIntent: AppIntent {
         let completedTitles = tasks.filter(\.isCompleted).map(\.title)
         let partialTitles = tasks.filter(\.isPartial).map(\.title)
 
-        let records = (try? context.fetch(FetchDescriptor<DayRecord>())) ?? []
+        let records = (try? context.fetch(
+            FetchDescriptor<DayRecord>(
+                predicate: #Predicate { $0.userId == currentUserId }
+            )
+        )) ?? []
         if let existing = records.first(where: { $0.dateString == today }) {
             existing.allTaskTitles = allTitles
             existing.completedTaskTitles = completedTitles
@@ -51,7 +60,8 @@ struct ToggleTaskIntent: AppIntent {
                 dateString: today,
                 allTaskTitles: allTitles,
                 completedTaskTitles: completedTitles,
-                partiallyCompletedTaskTitles: partialTitles
+                partiallyCompletedTaskTitles: partialTitles,
+                userId: currentUserId
             ))
         }
         try? context.save()

--- a/Shared/Models/DayRecord.swift
+++ b/Shared/Models/DayRecord.swift
@@ -4,6 +4,7 @@ import SwiftData
 @Model
 final class DayRecord {
     var id: UUID
+    var userId: String
     /// Date stored as "yyyy-MM-dd" string for easy keying
     var dateString: String
     /// All task titles that existed this day (for showing incomplete tasks in summary)
@@ -21,8 +22,9 @@ final class DayRecord {
         return (Double(completedCount) + Double(partialCount) * 0.5) / Double(totalTaskCount)
     }
 
-    init(dateString: String, allTaskTitles: [String], completedTaskTitles: [String], partiallyCompletedTaskTitles: [String] = []) {
+    init(dateString: String, allTaskTitles: [String], completedTaskTitles: [String], partiallyCompletedTaskTitles: [String] = [], userId: String = "") {
         self.id = UUID()
+        self.userId = userId
         self.dateString = dateString
         self.allTaskTitles = allTaskTitles
         self.completedTaskTitles = completedTaskTitles

--- a/Shared/Models/DayRecord.swift
+++ b/Shared/Models/DayRecord.swift
@@ -4,7 +4,7 @@ import SwiftData
 @Model
 final class DayRecord {
     var id: UUID
-    var userId: String
+    @Attribute var userId: String
     /// Date stored as "yyyy-MM-dd" string for easy keying
     var dateString: String
     /// All task titles that existed this day (for showing incomplete tasks in summary)

--- a/Shared/Models/TaskItem.swift
+++ b/Shared/Models/TaskItem.swift
@@ -4,7 +4,7 @@ import SwiftData
 @Model
 final class TaskItem {
     var id: UUID
-    var userId: String
+    @Attribute var userId: String
     var title: String
     var isCompleted: Bool
     var isPartial: Bool

--- a/Shared/Models/TaskItem.swift
+++ b/Shared/Models/TaskItem.swift
@@ -4,14 +4,16 @@ import SwiftData
 @Model
 final class TaskItem {
     var id: UUID
+    var userId: String
     var title: String
     var isCompleted: Bool
     var isPartial: Bool
     var orderIndex: Int
     var createdAt: Date
 
-    init(title: String, orderIndex: Int = 0) {
+    init(title: String, orderIndex: Int = 0, userId: String = "") {
         self.id = UUID()
+        self.userId = userId
         self.title = title
         self.isCompleted = false
         self.isPartial = false


### PR DESCRIPTION
Add a userId field to DayRecord and TaskItem SwiftData models so each
record is scoped to the user who created it. Filter all @Query calls in
CalendarView, DaySummaryView, and TasksView by the current userId so only
the signed-in user's data is shown. Thread userId from DailyTrackerApp
(resolved after Supabase signInIfNeeded) through ContentView to every
view that needs it. ContentView backfills existing legacy records (empty
userId) with the current userId on first sign-in. The widget intent reads
userId from SharedDefaults (written by the main app on sign-in) to stay
in sync. Also fix SupabaseManager.deleteTask to include the user_id
filter, preventing accidental cross-user deletes.

https://claude.ai/code/session_01GgKEoc8zq43p6krXgBGW1f