### PR TITLE
Add account recovery via email and cloud data restore

### DIFF
--- a/DailyTracker/ContentView.swift
+++ b/DailyTracker/ContentView.swift
@@ -5,8 +5,6 @@ struct ContentView: View {
     let userId: String
 
     @Environment(\.modelContext) private var modelContext
-    @Query(filter: #Predicate<DayRecord> { $0.userId == "" }) private var legacyRecords: [DayRecord]
-    @Query(filter: #Predicate<TaskItem> { $0.userId == "" }) private var legacyTasks: [TaskItem]
 
     var body: some View {
         TabView {
@@ -22,9 +20,65 @@ struct ContentView: View {
         }
         .onChange(of: userId) { _, newId in
             guard !newId.isEmpty else { return }
-            for record in legacyRecords { record.userId = newId }
-            for task in legacyTasks { task.userId = newId }
-            try? modelContext.save()
+            adoptOrphanedData(to: newId)
         }
+    }
+
+    /// Rebinds records stored under a stale identity to the current user.
+    /// Covers both pre-auth legacy data (userId == "") and data orphaned when
+    /// a failed session restore minted a fresh anonymous user. The app is
+    /// single-user per device, so any non-matching userId is a past identity
+    /// of the same person.
+    private func adoptOrphanedData(to newId: String) {
+        let orphanedTasks = (try? modelContext.fetch(
+            FetchDescriptor<TaskItem>(predicate: #Predicate { $0.userId != newId })
+        )) ?? []
+        let orphanedRecords = (try? modelContext.fetch(
+            FetchDescriptor<DayRecord>(predicate: #Predicate { $0.userId != newId })
+        )) ?? []
+        guard !orphanedTasks.isEmpty || !orphanedRecords.isEmpty else { return }
+
+        let currentTasks = (try? modelContext.fetch(
+            FetchDescriptor<TaskItem>(predicate: #Predicate { $0.userId == newId })
+        )) ?? []
+        let currentRecords = (try? modelContext.fetch(
+            FetchDescriptor<DayRecord>(predicate: #Predicate { $0.userId == newId })
+        )) ?? []
+
+        var existingTitles = Set(currentTasks.map(\.title))
+        var nextOrderIndex = (currentTasks.map(\.orderIndex).max() ?? -1) + 1
+        for task in orphanedTasks {
+            if existingTitles.contains(task.title) {
+                modelContext.delete(task)
+            } else {
+                task.userId = newId
+                task.orderIndex = nextOrderIndex
+                nextOrderIndex += 1
+                existingTitles.insert(task.title)
+            }
+        }
+
+        var recordsByDate = Dictionary(
+            currentRecords.map { ($0.dateString, $0) },
+            uniquingKeysWith: { first, _ in first }
+        )
+        for record in orphanedRecords {
+            if let existing = recordsByDate[record.dateString] {
+                existing.allTaskTitles = merged(existing.allTaskTitles, record.allTaskTitles)
+                existing.completedTaskTitles = merged(existing.completedTaskTitles, record.completedTaskTitles)
+                existing.partiallyCompletedTaskTitles = merged(existing.partiallyCompletedTaskTitles, record.partiallyCompletedTaskTitles)
+                modelContext.delete(record)
+            } else {
+                record.userId = newId
+                recordsByDate[record.dateString] = record
+            }
+        }
+
+        try? modelContext.save()
+    }
+
+    private func merged(_ first: [String], _ second: [String]) -> [String] {
+        var seen = Set(first)
+        return first + second.filter { seen.insert($0).inserted }
     }
 }

--- a/DailyTracker/ContentView.swift
+++ b/DailyTracker/ContentView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import SwiftData
+import WidgetKit
 
 struct ContentView: View {
     let userId: String
@@ -18,10 +19,77 @@ struct ContentView: View {
                     Label("Calendar", systemImage: "calendar")
                 }
         }
-        .onChange(of: userId) { _, newId in
-            guard !newId.isEmpty else { return }
-            adoptOrphanedData(to: newId)
+        .task(id: userId) {
+            guard !userId.isEmpty else { return }
+            adoptOrphanedData(to: userId)
+            await restoreFromCloudIfNeeded()
         }
+    }
+
+    /// Pulls this user's tasks and history down from Supabase. Runs after an
+    /// account recovery, or when the local store has nothing for this user
+    /// (fresh install / new device). The cloud is otherwise write-only, so
+    /// without this there is no way to get server-side data back.
+    private func restoreFromCloudIfNeeded() async {
+        let defaults = SharedDataStore.sharedDefaults
+        let flagged = defaults.bool(forKey: "needsCloudRestore")
+        let uid = userId
+
+        let localTasks = (try? modelContext.fetch(
+            FetchDescriptor<TaskItem>(predicate: #Predicate { $0.userId == uid })
+        )) ?? []
+        let localRecords = (try? modelContext.fetch(
+            FetchDescriptor<DayRecord>(predicate: #Predicate { $0.userId == uid })
+        )) ?? []
+        guard flagged || (localTasks.isEmpty && localRecords.isEmpty) else { return }
+
+        let remoteTasks = await SupabaseManager.shared.fetchRemoteTasks()
+        let remoteRecords = await SupabaseManager.shared.fetchRemoteDayRecords()
+        defaults.set(false, forKey: "needsCloudRestore")
+        guard !remoteTasks.isEmpty || !remoteRecords.isEmpty else { return }
+
+        var existingTaskIds = Set(localTasks.map(\.id))
+        var existingTitles = Set(localTasks.map(\.title))
+        var nextOrderIndex = (localTasks.map(\.orderIndex).max() ?? -1) + 1
+        for remote in remoteTasks {
+            guard !existingTaskIds.contains(remote.id),
+                  !existingTitles.contains(remote.title) else { continue }
+            let task = TaskItem(title: remote.title, orderIndex: nextOrderIndex, userId: userId)
+            task.id = remote.id
+            task.isCompleted = remote.isCompleted
+            task.isPartial = remote.isPartial
+            task.createdAt = remote.createdAt
+            modelContext.insert(task)
+            existingTaskIds.insert(remote.id)
+            existingTitles.insert(remote.title)
+            nextOrderIndex += 1
+        }
+
+        var recordsByDate = Dictionary(
+            localRecords.map { ($0.dateString, $0) },
+            uniquingKeysWith: { first, _ in first }
+        )
+        for remote in remoteRecords {
+            if let existing = recordsByDate[remote.dateString] {
+                existing.allTaskTitles = merged(existing.allTaskTitles, remote.allTaskTitles)
+                existing.completedTaskTitles = merged(existing.completedTaskTitles, remote.completedTaskTitles)
+                existing.partiallyCompletedTaskTitles = merged(existing.partiallyCompletedTaskTitles, remote.partiallyCompletedTaskTitles)
+            } else {
+                let record = DayRecord(
+                    dateString: remote.dateString,
+                    allTaskTitles: remote.allTaskTitles,
+                    completedTaskTitles: remote.completedTaskTitles,
+                    partiallyCompletedTaskTitles: remote.partiallyCompletedTaskTitles,
+                    userId: userId
+                )
+                record.id = remote.id
+                modelContext.insert(record)
+                recordsByDate[remote.dateString] = record
+            }
+        }
+
+        try? modelContext.save()
+        WidgetCenter.shared.reloadAllTimelines()
     }
 
     /// Rebinds records stored under a stale identity to the current user.

--- a/DailyTracker/ContentView.swift
+++ b/DailyTracker/ContentView.swift
@@ -4,8 +4,18 @@ import WidgetKit
 
 struct ContentView: View {
     let userId: String
+    /// True only when `userId` is backed by a real Supabase session (see
+    /// SupabaseManager.isAuthenticated). Adoption and cloud restore must not
+    /// run against a merely-cached identity — if the cache and the eventual
+    /// session ever disagreed, that would silently mix two accounts' data.
+    let isAuthenticated: Bool
 
     @Environment(\.modelContext) private var modelContext
+
+    private struct SyncKey: Equatable {
+        let userId: String
+        let isAuthenticated: Bool
+    }
 
     var body: some View {
         TabView {
@@ -19,12 +29,14 @@ struct ContentView: View {
                     Label("Calendar", systemImage: "calendar")
                 }
         }
-        .task(id: userId) {
-            guard !userId.isEmpty else { return }
+        .task(id: SyncKey(userId: userId, isAuthenticated: isAuthenticated)) {
+            guard isAuthenticated, !userId.isEmpty else { return }
             adoptOrphanedData(to: userId)
             await restoreFromCloudIfNeeded()
         }
     }
+
+    // MARK: - Cloud Restore
 
     /// Pulls this user's tasks and history down from Supabase. Runs after an
     /// account recovery, or when the local store has nothing for this user
@@ -32,8 +44,41 @@ struct ContentView: View {
     /// without this there is no way to get server-side data back.
     private func restoreFromCloudIfNeeded() async {
         let defaults = SharedDataStore.sharedDefaults
-        let flagged = defaults.bool(forKey: "needsCloudRestore")
         let uid = userId
+        let flagged = defaults.bool(forKey: "needsCloudRestore")
+        // Per-user marker so a genuinely-empty account doesn't hit the
+        // network on every single launch forever — but a pending recovery
+        // (`flagged`) always overrides it and forces a fresh attempt.
+        let checkedKey = "cloudRestoreChecked-\(uid)"
+        guard flagged || !defaults.bool(forKey: checkedKey) else { return }
+
+        let localTaskCount = (try? modelContext.fetchCount(
+            FetchDescriptor<TaskItem>(predicate: #Predicate { $0.userId == uid })
+        )) ?? 0
+        let localRecordCount = (try? modelContext.fetchCount(
+            FetchDescriptor<DayRecord>(predicate: #Predicate { $0.userId == uid })
+        )) ?? 0
+        guard flagged || (localTaskCount == 0 && localRecordCount == 0) else {
+            defaults.set(true, forKey: checkedKey)
+            return
+        }
+
+        let remoteTasks: [TaskItemRow]
+        let remoteRecords: [DayRecordRow]
+        do {
+            async let tasksFetch = SupabaseManager.shared.fetchRemoteTasks()
+            async let recordsFetch = SupabaseManager.shared.fetchRemoteDayRecords()
+            (remoteTasks, remoteRecords) = try await (tasksFetch, recordsFetch)
+        } catch {
+            // Don't touch either flag: a network failure should be retried
+            // on the next launch, not treated as "there's nothing to restore".
+            print("[Restore] fetch failed, will retry: \(error)")
+            return
+        }
+
+        defaults.set(false, forKey: "needsCloudRestore")
+        defaults.set(true, forKey: checkedKey)
+        guard !remoteTasks.isEmpty || !remoteRecords.isEmpty else { return }
 
         let localTasks = (try? modelContext.fetch(
             FetchDescriptor<TaskItem>(predicate: #Predicate { $0.userId == uid })
@@ -41,12 +86,6 @@ struct ContentView: View {
         let localRecords = (try? modelContext.fetch(
             FetchDescriptor<DayRecord>(predicate: #Predicate { $0.userId == uid })
         )) ?? []
-        guard flagged || (localTasks.isEmpty && localRecords.isEmpty) else { return }
-
-        let remoteTasks = await SupabaseManager.shared.fetchRemoteTasks()
-        let remoteRecords = await SupabaseManager.shared.fetchRemoteDayRecords()
-        defaults.set(false, forKey: "needsCloudRestore")
-        guard !remoteTasks.isEmpty || !remoteRecords.isEmpty else { return }
 
         var existingTaskIds = Set(localTasks.map(\.id))
         var existingTitles = Set(localTasks.map(\.title))
@@ -54,7 +93,7 @@ struct ContentView: View {
         for remote in remoteTasks {
             guard !existingTaskIds.contains(remote.id),
                   !existingTitles.contains(remote.title) else { continue }
-            let task = TaskItem(title: remote.title, orderIndex: nextOrderIndex, userId: userId)
+            let task = TaskItem(title: remote.title, orderIndex: nextOrderIndex, userId: uid)
             task.id = remote.id
             task.isCompleted = remote.isCompleted
             task.isPartial = remote.isPartial
@@ -71,16 +110,26 @@ struct ContentView: View {
         )
         for remote in remoteRecords {
             if let existing = recordsByDate[remote.dateString] {
-                existing.allTaskTitles = merged(existing.allTaskTitles, remote.allTaskTitles)
-                existing.completedTaskTitles = merged(existing.completedTaskTitles, remote.completedTaskTitles)
-                existing.partiallyCompletedTaskTitles = merged(existing.partiallyCompletedTaskTitles, remote.partiallyCompletedTaskTitles)
+                mergeTitles(
+                    into: existing,
+                    all: remote.allTaskTitles,
+                    completed: remote.completedTaskTitles,
+                    partial: remote.partiallyCompletedTaskTitles
+                )
+                // Adopt the server's id for this date: `existing` was created
+                // locally (e.g. while offline) and never synced, so its id
+                // has no row on the server. Taking over remote.id makes the
+                // next upsert an unambiguous PK match instead of an INSERT
+                // that would violate the unique (user_id, date_string)
+                // constraint against the row we just merged in.
+                existing.id = remote.id
             } else {
                 let record = DayRecord(
                     dateString: remote.dateString,
                     allTaskTitles: remote.allTaskTitles,
                     completedTaskTitles: remote.completedTaskTitles,
                     partiallyCompletedTaskTitles: remote.partiallyCompletedTaskTitles,
-                    userId: userId
+                    userId: uid
                 )
                 record.id = remote.id
                 modelContext.insert(record)
@@ -92,19 +141,33 @@ struct ContentView: View {
         WidgetCenter.shared.reloadAllTimelines()
     }
 
+    // MARK: - Orphan Adoption
+
     /// Rebinds records stored under a stale identity to the current user.
     /// Covers both pre-auth legacy data (userId == "") and data orphaned when
     /// a failed session restore minted a fresh anonymous user. The app is
     /// single-user per device, so any non-matching userId is a past identity
     /// of the same person.
     private func adoptOrphanedData(to newId: String) {
-        let orphanedTasks = (try? modelContext.fetch(
+        let orphanTaskCount = (try? modelContext.fetchCount(
             FetchDescriptor<TaskItem>(predicate: #Predicate { $0.userId != newId })
+        )) ?? 0
+        let orphanRecordCount = (try? modelContext.fetchCount(
+            FetchDescriptor<DayRecord>(predicate: #Predicate { $0.userId != newId })
+        )) ?? 0
+        guard orphanTaskCount > 0 || orphanRecordCount > 0 else { return }
+
+        // Sorted so re-numbering below preserves the orphaned list's relative
+        // order instead of scrambling it into fetch-order.
+        let orphanedTasks = (try? modelContext.fetch(
+            FetchDescriptor<TaskItem>(
+                predicate: #Predicate { $0.userId != newId },
+                sortBy: [SortDescriptor(\.orderIndex)]
+            )
         )) ?? []
         let orphanedRecords = (try? modelContext.fetch(
             FetchDescriptor<DayRecord>(predicate: #Predicate { $0.userId != newId })
         )) ?? []
-        guard !orphanedTasks.isEmpty || !orphanedRecords.isEmpty else { return }
 
         let currentTasks = (try? modelContext.fetch(
             FetchDescriptor<TaskItem>(predicate: #Predicate { $0.userId == newId })
@@ -113,16 +176,32 @@ struct ContentView: View {
             FetchDescriptor<DayRecord>(predicate: #Predicate { $0.userId == newId })
         )) ?? []
 
-        var existingTitles = Set(currentTasks.map(\.title))
+        var tasksByTitle = Dictionary(
+            currentTasks.map { ($0.title, $0) },
+            uniquingKeysWith: { first, _ in first }
+        )
         var nextOrderIndex = (currentTasks.map(\.orderIndex).max() ?? -1) + 1
         for task in orphanedTasks {
-            if existingTitles.contains(task.title) {
+            if let existing = tasksByTitle[task.title] {
+                // Same-titled task already exists under the current
+                // identity. Keep whichever copy has more progress instead of
+                // always discarding the orphan, so an in-progress task never
+                // silently reverts to unstarted.
+                if progress(of: task) > progress(of: existing) {
+                    existing.isCompleted = task.isCompleted
+                    existing.isPartial = task.isPartial
+                }
                 modelContext.delete(task)
             } else {
                 task.userId = newId
+                // A fresh id: this task's old id may already be a synced row
+                // owned by the now-unreachable prior identity, and reusing it
+                // would make every future upsert collide with that row
+                // (RLS-blocked) instead of creating this account's own.
+                task.id = UUID()
                 task.orderIndex = nextOrderIndex
                 nextOrderIndex += 1
-                existingTitles.insert(task.title)
+                tasksByTitle[task.title] = task
             }
         }
 
@@ -132,17 +211,36 @@ struct ContentView: View {
         )
         for record in orphanedRecords {
             if let existing = recordsByDate[record.dateString] {
-                existing.allTaskTitles = merged(existing.allTaskTitles, record.allTaskTitles)
-                existing.completedTaskTitles = merged(existing.completedTaskTitles, record.completedTaskTitles)
-                existing.partiallyCompletedTaskTitles = merged(existing.partiallyCompletedTaskTitles, record.partiallyCompletedTaskTitles)
+                mergeTitles(
+                    into: existing,
+                    all: record.allTaskTitles,
+                    completed: record.completedTaskTitles,
+                    partial: record.partiallyCompletedTaskTitles
+                )
                 modelContext.delete(record)
             } else {
                 record.userId = newId
+                record.id = UUID()
                 recordsByDate[record.dateString] = record
             }
         }
 
         try? modelContext.save()
+        WidgetCenter.shared.reloadAllTimelines()
+    }
+
+    // MARK: - Shared merge helpers
+
+    private func progress(of task: TaskItem) -> Int {
+        if task.isCompleted { return 2 }
+        if task.isPartial { return 1 }
+        return 0
+    }
+
+    private func mergeTitles(into record: DayRecord, all: [String], completed: [String], partial: [String]) {
+        record.allTaskTitles = merged(record.allTaskTitles, all)
+        record.completedTaskTitles = merged(record.completedTaskTitles, completed)
+        record.partiallyCompletedTaskTitles = merged(record.partiallyCompletedTaskTitles, partial)
     }
 
     private func merged(_ first: [String], _ second: [String]) -> [String] {

--- a/DailyTracker/DailyTrackerApp.swift
+++ b/DailyTracker/DailyTrackerApp.swift
@@ -4,24 +4,34 @@ import SwiftData
 @main
 struct DailyTrackerApp: App {
     let sharedModelContainer: ModelContainer = SharedDataStore.makeContainer()
-    @State private var userId: String = ""
 
     var body: some Scene {
         WindowGroup {
-            ContentView(userId: userId)
-                .task {
-                    await SupabaseManager.shared.signInIfNeeded()
-                    if let resolvedId = SupabaseManager.shared.userId?.uuidString {
-                        SharedDataStore.sharedDefaults.set(resolvedId, forKey: "currentUserId")
-                        userId = resolvedId
-                    } else if let cached = SharedDataStore.sharedDefaults.string(forKey: "currentUserId"),
-                              !cached.isEmpty {
-                        // Auth unavailable (e.g. offline first launch after reboot):
-                        // keep showing the data for the last known user.
-                        userId = cached
-                    }
-                }
+            RootView()
         }
         .modelContainer(sharedModelContainer)
+    }
+}
+
+/// Bridges the observable auth state into the view tree so the UI re-queries
+/// whenever the signed-in user changes (initial sign-in or account recovery).
+struct RootView: View {
+    private let supabase = SupabaseManager.shared
+
+    /// Last known user, so the app keeps showing data when auth is
+    /// temporarily unavailable (e.g. offline right after a reboot).
+    @State private var fallbackUserId: String =
+        SharedDataStore.sharedDefaults.string(forKey: "currentUserId") ?? ""
+
+    var body: some View {
+        ContentView(userId: supabase.userId?.uuidString ?? fallbackUserId)
+            .task {
+                await supabase.signInIfNeeded()
+            }
+            .onChange(of: supabase.userId) { _, newId in
+                guard let newId else { return }
+                SharedDataStore.sharedDefaults.set(newId.uuidString, forKey: "currentUserId")
+                fallbackUserId = newId.uuidString
+            }
     }
 }

--- a/DailyTracker/DailyTrackerApp.swift
+++ b/DailyTracker/DailyTrackerApp.swift
@@ -11,9 +11,15 @@ struct DailyTrackerApp: App {
             ContentView(userId: userId)
                 .task {
                     await SupabaseManager.shared.signInIfNeeded()
-                    let resolvedId = SupabaseManager.shared.userId?.uuidString ?? ""
-                    SharedDataStore.sharedDefaults.set(resolvedId, forKey: "currentUserId")
-                    userId = resolvedId
+                    if let resolvedId = SupabaseManager.shared.userId?.uuidString {
+                        SharedDataStore.sharedDefaults.set(resolvedId, forKey: "currentUserId")
+                        userId = resolvedId
+                    } else if let cached = SharedDataStore.sharedDefaults.string(forKey: "currentUserId"),
+                              !cached.isEmpty {
+                        // Auth unavailable (e.g. offline first launch after reboot):
+                        // keep showing the data for the last known user.
+                        userId = cached
+                    }
                 }
         }
         .modelContainer(sharedModelContainer)

--- a/DailyTracker/DailyTrackerApp.swift
+++ b/DailyTracker/DailyTrackerApp.swift
@@ -17,21 +17,19 @@ struct DailyTrackerApp: App {
 /// whenever the signed-in user changes (initial sign-in or account recovery).
 struct RootView: View {
     private let supabase = SupabaseManager.shared
-
-    /// Last known user, so the app keeps showing data when auth is
-    /// temporarily unavailable (e.g. offline right after a reboot).
-    @State private var fallbackUserId: String =
-        SharedDataStore.sharedDefaults.string(forKey: "currentUserId") ?? ""
+    @Environment(\.scenePhase) private var scenePhase
 
     var body: some View {
-        ContentView(userId: supabase.userId?.uuidString ?? fallbackUserId)
+        ContentView(userId: supabase.userId?.uuidString ?? "", isAuthenticated: supabase.isAuthenticated)
             .task {
                 await supabase.signInIfNeeded()
             }
-            .onChange(of: supabase.userId) { _, newId in
-                guard let newId else { return }
-                SharedDataStore.sharedDefaults.set(newId.uuidString, forKey: "currentUserId")
-                fallbackUserId = newId.uuidString
+            .onChange(of: scenePhase) { _, newPhase in
+                // A session-load failure at launch (e.g. no network right
+                // after a reboot) isn't permanent — retry whenever the app
+                // comes back to the foreground until it succeeds.
+                guard newPhase == .active, !supabase.isAuthenticated else { return }
+                Task { await supabase.signInIfNeeded() }
             }
     }
 }

--- a/DailyTracker/SupabaseManager.swift
+++ b/DailyTracker/SupabaseManager.swift
@@ -1,7 +1,9 @@
 import Foundation
+import Observation
 import Supabase
 
 @MainActor
+@Observable
 final class SupabaseManager {
     static let shared = SupabaseManager()
 
@@ -11,6 +13,9 @@ final class SupabaseManager {
     )
 
     private(set) var userId: UUID?
+    /// Email linked to the current account, if any. A linked email makes the
+    /// account recoverable even if the local session is ever lost.
+    private(set) var linkedEmail: String?
 
     private init() {}
 
@@ -18,6 +23,7 @@ final class SupabaseManager {
         do {
             let session = try await client.auth.session
             userId = session.user.id
+            linkedEmail = session.user.email
             return
         } catch {
             print("[Supabase] session load error: \(error)")
@@ -29,6 +35,7 @@ final class SupabaseManager {
         // back to the identity we already know about instead.
         if let session = client.auth.currentSession {
             userId = session.user.id
+            linkedEmail = session.user.email
             return
         }
         if let cached = SharedDataStore.sharedDefaults.string(forKey: "currentUserId"),
@@ -45,6 +52,99 @@ final class SupabaseManager {
             print("[Supabase] Auth error: \(error)")
         }
     }
+
+    // MARK: - Email linking & account recovery
+
+    /// Attaches an email to the current (anonymous) account. Supabase sends a
+    /// confirmation link; once the user taps it the email is active and the
+    /// account can be recovered on any device via `sendRecoveryCode`.
+    func linkEmail(_ email: String) async throws {
+        try await client.auth.update(user: UserAttributes(email: email))
+    }
+
+    /// Emails a one-time sign-in code. `shouldCreateUser: false` ensures this
+    /// can only reach an existing account and never silently mints a new one.
+    func sendRecoveryCode(to email: String) async throws {
+        try await client.auth.signInWithOTP(email: email, shouldCreateUser: false)
+    }
+
+    /// Verifies the emailed code and switches this device to the recovered
+    /// account. Marks the local store for a cloud restore so the recovered
+    /// account's data is pulled back down.
+    func verifyRecoveryCode(email: String, code: String) async throws {
+        let response = try await client.auth.verifyOTP(email: email, token: code, type: .email)
+        userId = response.user.id
+        linkedEmail = response.user.email
+        SharedDataStore.sharedDefaults.set(response.user.id.uuidString, forKey: "currentUserId")
+        SharedDataStore.sharedDefaults.set(true, forKey: "needsCloudRestore")
+    }
+
+    // MARK: - Cloud restore (read path)
+
+    struct RemoteTask: Decodable {
+        let id: UUID
+        let title: String
+        let isCompleted: Bool
+        let isPartial: Bool
+        let orderIndex: Int
+        let createdAt: Date
+
+        enum CodingKeys: String, CodingKey {
+            case id
+            case title
+            case isCompleted = "is_completed"
+            case isPartial = "is_partial"
+            case orderIndex = "order_index"
+            case createdAt = "created_at"
+        }
+    }
+
+    struct RemoteDayRecord: Decodable {
+        let id: UUID
+        let dateString: String
+        let allTaskTitles: [String]
+        let completedTaskTitles: [String]
+        let partiallyCompletedTaskTitles: [String]
+
+        enum CodingKeys: String, CodingKey {
+            case id
+            case dateString = "date_string"
+            case allTaskTitles = "all_task_titles"
+            case completedTaskTitles = "completed_task_titles"
+            case partiallyCompletedTaskTitles = "partially_completed_task_titles"
+        }
+    }
+
+    func fetchRemoteTasks() async -> [RemoteTask] {
+        guard let userId else { return [] }
+        do {
+            return try await client.from("task_items")
+                .select()
+                .eq("user_id", value: userId.uuidString)
+                .order("order_index")
+                .execute()
+                .value
+        } catch {
+            print("[Supabase] fetch tasks error: \(error)")
+            return []
+        }
+    }
+
+    func fetchRemoteDayRecords() async -> [RemoteDayRecord] {
+        guard let userId else { return [] }
+        do {
+            return try await client.from("day_records")
+                .select()
+                .eq("user_id", value: userId.uuidString)
+                .execute()
+                .value
+        } catch {
+            print("[Supabase] fetch day records error: \(error)")
+            return []
+        }
+    }
+
+    // MARK: - Write path
 
     func upsertTask(_ task: TaskItem) async {
         guard let userId else { return }

--- a/DailyTracker/SupabaseManager.swift
+++ b/DailyTracker/SupabaseManager.swift
@@ -18,13 +18,31 @@ final class SupabaseManager {
         do {
             let session = try await client.auth.session
             userId = session.user.id
+            return
         } catch {
-            do {
-                let session = try await client.auth.signInAnonymously()
-                userId = session.user.id
-            } catch {
-                print("[Supabase] Auth error: \(error)")
-            }
+            print("[Supabase] session load error: \(error)")
+        }
+
+        // A failure above (e.g. token refresh with no network right after a
+        // reboot) does not mean the account is gone. Creating a new anonymous
+        // user here would orphan all data keyed to the old user ID, so fall
+        // back to the identity we already know about instead.
+        if let session = client.auth.currentSession {
+            userId = session.user.id
+            return
+        }
+        if let cached = SharedDataStore.sharedDefaults.string(forKey: "currentUserId"),
+           let cachedId = UUID(uuidString: cached) {
+            userId = cachedId
+            return
+        }
+
+        // No stored session and no previously known user: true first launch.
+        do {
+            let session = try await client.auth.signInAnonymously()
+            userId = session.user.id
+        } catch {
+            print("[Supabase] Auth error: \(error)")
         }
     }
 

--- a/DailyTracker/SupabaseManager.swift
+++ b/DailyTracker/SupabaseManager.swift
@@ -16,14 +16,28 @@ final class SupabaseManager {
     /// Email linked to the current account, if any. A linked email makes the
     /// account recoverable even if the local session is ever lost.
     private(set) var linkedEmail: String?
+    /// True only when `userId` is backed by a real Supabase session. False
+    /// means `userId` is a locally-cached last-known identity (shown so the
+    /// app isn't blank while offline) — writes and cloud reads must not run
+    /// against it, since there is no session to authorize them.
+    private(set) var isAuthenticated = false
 
-    private init() {}
+    private static let currentUserIdKey = "currentUserId"
+
+    private init() {
+        // Seed synchronously from the cache so the very first frame can show
+        // the last known user's data while signInIfNeeded() resolves in the
+        // background. isAuthenticated stays false until a real session backs it.
+        if let cached = SharedDataStore.sharedDefaults.string(forKey: Self.currentUserIdKey),
+           let cachedId = UUID(uuidString: cached) {
+            userId = cachedId
+        }
+    }
 
     func signInIfNeeded() async {
         do {
             let session = try await client.auth.session
-            userId = session.user.id
-            linkedEmail = session.user.email
+            applyAuthenticatedSession(session)
             return
         } catch {
             print("[Supabase] session load error: \(error)")
@@ -32,25 +46,32 @@ final class SupabaseManager {
         // A failure above (e.g. token refresh with no network right after a
         // reboot) does not mean the account is gone. Creating a new anonymous
         // user here would orphan all data keyed to the old user ID, so fall
-        // back to the identity we already know about instead.
+        // back to the identity we already know about instead, and let the
+        // caller retry signInIfNeeded later (e.g. on the next foreground)
+        // rather than ever minting a second account behind the user's back.
         if let session = client.auth.currentSession {
-            userId = session.user.id
-            linkedEmail = session.user.email
+            applyAuthenticatedSession(session)
             return
         }
-        if let cached = SharedDataStore.sharedDefaults.string(forKey: "currentUserId"),
-           let cachedId = UUID(uuidString: cached) {
-            userId = cachedId
+        if userId != nil {
+            isAuthenticated = false
             return
         }
 
         // No stored session and no previously known user: true first launch.
         do {
             let session = try await client.auth.signInAnonymously()
-            userId = session.user.id
+            applyAuthenticatedSession(session)
         } catch {
             print("[Supabase] Auth error: \(error)")
         }
+    }
+
+    private func applyAuthenticatedSession(_ session: Session) {
+        userId = session.user.id
+        linkedEmail = session.user.email
+        isAuthenticated = true
+        SharedDataStore.sharedDefaults.set(session.user.id.uuidString, forKey: Self.currentUserIdKey)
     }
 
     // MARK: - Email linking & account recovery
@@ -75,79 +96,44 @@ final class SupabaseManager {
         let response = try await client.auth.verifyOTP(email: email, token: code, type: .email)
         userId = response.user.id
         linkedEmail = response.user.email
-        SharedDataStore.sharedDefaults.set(response.user.id.uuidString, forKey: "currentUserId")
+        isAuthenticated = true
+        SharedDataStore.sharedDefaults.set(response.user.id.uuidString, forKey: Self.currentUserIdKey)
         SharedDataStore.sharedDefaults.set(true, forKey: "needsCloudRestore")
     }
 
     // MARK: - Cloud restore (read path)
 
-    struct RemoteTask: Decodable {
-        let id: UUID
-        let title: String
-        let isCompleted: Bool
-        let isPartial: Bool
-        let orderIndex: Int
-        let createdAt: Date
-
-        enum CodingKeys: String, CodingKey {
-            case id
-            case title
-            case isCompleted = "is_completed"
-            case isPartial = "is_partial"
-            case orderIndex = "order_index"
-            case createdAt = "created_at"
-        }
+    enum SyncError: Error {
+        case notAuthenticated
     }
 
-    struct RemoteDayRecord: Decodable {
-        let id: UUID
-        let dateString: String
-        let allTaskTitles: [String]
-        let completedTaskTitles: [String]
-        let partiallyCompletedTaskTitles: [String]
-
-        enum CodingKeys: String, CodingKey {
-            case id
-            case dateString = "date_string"
-            case allTaskTitles = "all_task_titles"
-            case completedTaskTitles = "completed_task_titles"
-            case partiallyCompletedTaskTitles = "partially_completed_task_titles"
-        }
+    /// Throws (rather than swallowing into an empty array) so callers doing a
+    /// one-shot restore can tell "confirmed nothing on the server" apart from
+    /// "the fetch failed" and only consume their one-shot restore flag on the
+    /// former.
+    func fetchRemoteTasks() async throws -> [TaskItemRow] {
+        guard isAuthenticated, let userId else { throw SyncError.notAuthenticated }
+        return try await client.from("task_items")
+            .select()
+            .eq("user_id", value: userId.uuidString)
+            .order("order_index")
+            .execute()
+            .value
     }
 
-    func fetchRemoteTasks() async -> [RemoteTask] {
-        guard let userId else { return [] }
-        do {
-            return try await client.from("task_items")
-                .select()
-                .eq("user_id", value: userId.uuidString)
-                .order("order_index")
-                .execute()
-                .value
-        } catch {
-            print("[Supabase] fetch tasks error: \(error)")
-            return []
-        }
-    }
-
-    func fetchRemoteDayRecords() async -> [RemoteDayRecord] {
-        guard let userId else { return [] }
-        do {
-            return try await client.from("day_records")
-                .select()
-                .eq("user_id", value: userId.uuidString)
-                .execute()
-                .value
-        } catch {
-            print("[Supabase] fetch day records error: \(error)")
-            return []
-        }
+    func fetchRemoteDayRecords() async throws -> [DayRecordRow] {
+        guard isAuthenticated, let userId else { throw SyncError.notAuthenticated }
+        return try await client.from("day_records")
+            .select()
+            .eq("user_id", value: userId.uuidString)
+            .execute()
+            .value
     }
 
     // MARK: - Write path
 
     func upsertTask(_ task: TaskItem) async {
-        guard let userId else { return }
+        guard isAuthenticated, let userId else { return }
         let record = TaskItemRow(
             id: task.id,
             userId: userId,
@@ -165,7 +151,7 @@ final class SupabaseManager {
     }
 
     func deleteTask(id: UUID) async {
-        guard let userId else { return }
+        guard isAuthenticated, let userId else { return }
         do {
             try await client.from("task_items")
                 .delete()
@@ -178,7 +164,7 @@ final class SupabaseManager {
     }
 
     func upsertDayRecord(_ record: DayRecord) async {
-        guard let userId else { return }
+        guard isAuthenticated, let userId else { return }
         let row = DayRecordRow(
             id: record.id,
             userId: userId,
@@ -188,14 +174,22 @@ final class SupabaseManager {
             partiallyCompletedTaskTitles: record.partiallyCompletedTaskTitles
         )
         do {
-            try await client.from("day_records").upsert(row).execute()
+            // Target the natural key (one row per user per day), not the
+            // primary key: a locally-created record's id can legitimately
+            // differ from a same-day row that already exists server-side
+            // (e.g. after merging in restored data), and a plain PK upsert
+            // would try to INSERT a second row and violate the unique
+            // (user_id, date_string) constraint instead of updating it.
+            try await client.from("day_records")
+                .upsert(row, onConflict: "user_id,date_string")
+                .execute()
         } catch {
             print("[Supabase] upsert day record error: \(error)")
         }
     }
 }
 
-private struct TaskItemRow: Encodable {
+struct TaskItemRow: Codable {
     let id: UUID
     let userId: UUID
     let title: String
@@ -215,7 +209,7 @@ private struct TaskItemRow: Encodable {
     }
 }
 
-private struct DayRecordRow: Encodable {
+struct DayRecordRow: Codable {
     let id: UUID
     let userId: UUID
     let dateString: String

--- a/DailyTracker/ViewModels/FriendsViewModel.swift
+++ b/DailyTracker/ViewModels/FriendsViewModel.swift
@@ -13,6 +13,11 @@ final class FriendsViewModel {
     private var userId: UUID? { SupabaseManager.shared.userId }
 
     func load() async {
+        // `userId` can be a cached last-known identity with no backing
+        // session (see SupabaseManager.isAuthenticated) — every call below
+        // is RLS-guarded and would just fail silently in that state, so
+        // don't bother making them.
+        guard SupabaseManager.shared.isAuthenticated else { return }
         isLoading = true
         defer { isLoading = false }
         await withTaskGroup(of: Void.self) { group in

--- a/DailyTracker/Views/Account/AccountRecoveryViews.swift
+++ b/DailyTracker/Views/Account/AccountRecoveryViews.swift
@@ -1,0 +1,195 @@
+import SwiftUI
+
+/// Links an email address to the current anonymous account so the account
+/// (and everything in it) can be recovered if the local session is ever lost.
+struct LinkEmailView: View {
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var email = ""
+    @State private var isSending = false
+    @State private var confirmationSent = false
+    @State private var errorMessage: String?
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                if confirmationSent {
+                    Section {
+                        Label("Confirmation email sent", systemImage: "envelope.badge")
+                        Text("Open the link in the email to finish linking \(email) to your account.")
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                    }
+                } else {
+                    Section {
+                        TextField("you@example.com", text: $email)
+                            .keyboardType(.emailAddress)
+                            .textContentType(.emailAddress)
+                            .textInputAutocapitalization(.never)
+                            .autocorrectionDisabled()
+                    } footer: {
+                        VStack(alignment: .leading, spacing: 4) {
+                            if let errorMessage {
+                                Text(errorMessage).foregroundStyle(.red)
+                            }
+                            Text("Your account and data stay on this device either way — linking an email just makes them recoverable if you ever get signed out.")
+                        }
+                    }
+                }
+            }
+            .navigationTitle("Link Email")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(confirmationSent ? "Done" : "Cancel") { dismiss() }
+                }
+                if !confirmationSent {
+                    ToolbarItem(placement: .confirmationAction) {
+                        Button("Send") { sendConfirmation() }
+                            .disabled(isSending || !email.contains("@"))
+                    }
+                }
+            }
+        }
+    }
+
+    private func sendConfirmation() {
+        isSending = true
+        errorMessage = nil
+        Task {
+            do {
+                try await SupabaseManager.shared.linkEmail(
+                    email.trimmingCharacters(in: .whitespaces)
+                )
+                confirmationSent = true
+            } catch {
+                errorMessage = "Couldn't send the confirmation email. Check the address and try again."
+                print("[Account] link email error: \(error)")
+            }
+            isSending = false
+        }
+    }
+}
+
+/// Signs this device back into an existing account using a one-time code
+/// sent to the account's linked email. On success the app rebinds local data
+/// and pulls the account's data down from the server.
+struct RecoverAccountView: View {
+    @Environment(\.dismiss) private var dismiss
+
+    private enum Step {
+        case enterEmail
+        case enterCode
+        case done
+    }
+
+    @State private var step: Step = .enterEmail
+    @State private var email = ""
+    @State private var code = ""
+    @State private var isWorking = false
+    @State private var errorMessage: String?
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                switch step {
+                case .enterEmail:
+                    Section {
+                        TextField("you@example.com", text: $email)
+                            .keyboardType(.emailAddress)
+                            .textContentType(.emailAddress)
+                            .textInputAutocapitalization(.never)
+                            .autocorrectionDisabled()
+                    } footer: {
+                        VStack(alignment: .leading, spacing: 4) {
+                            if let errorMessage {
+                                Text(errorMessage).foregroundStyle(.red)
+                            }
+                            Text("Enter the email linked to the account you want to recover. We'll send a one-time code.")
+                        }
+                    }
+
+                case .enterCode:
+                    Section {
+                        TextField("6-digit code", text: $code)
+                            .keyboardType(.numberPad)
+                            .textContentType(.oneTimeCode)
+                            .font(.system(.title3, design: .monospaced))
+                    } footer: {
+                        VStack(alignment: .leading, spacing: 4) {
+                            if let errorMessage {
+                                Text(errorMessage).foregroundStyle(.red)
+                            }
+                            Text("Enter the code sent to \(email).")
+                        }
+                    }
+                    Button("Send a new code") { sendCode() }
+                        .disabled(isWorking)
+
+                case .done:
+                    Section {
+                        Label("Account recovered", systemImage: "checkmark.circle.fill")
+                            .foregroundStyle(.green)
+                        Text("Your tasks and calendar history are being restored. They'll appear in a moment.")
+                            .font(.subheadline)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+            }
+            .navigationTitle("Recover Account")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(step == .done ? "Done" : "Cancel") { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    switch step {
+                    case .enterEmail:
+                        Button("Send Code") { sendCode() }
+                            .disabled(isWorking || !email.contains("@"))
+                    case .enterCode:
+                        Button("Verify") { verifyCode() }
+                            .disabled(isWorking || code.trimmingCharacters(in: .whitespaces).count < 6)
+                    case .done:
+                        EmptyView()
+                    }
+                }
+            }
+        }
+    }
+
+    private func sendCode() {
+        isWorking = true
+        errorMessage = nil
+        Task {
+            do {
+                try await SupabaseManager.shared.sendRecoveryCode(
+                    to: email.trimmingCharacters(in: .whitespaces)
+                )
+                step = .enterCode
+            } catch {
+                errorMessage = "Couldn't send a code to that address. Make sure it's the email linked to your account."
+                print("[Account] send recovery code error: \(error)")
+            }
+            isWorking = false
+        }
+    }
+
+    private func verifyCode() {
+        isWorking = true
+        errorMessage = nil
+        Task {
+            do {
+                try await SupabaseManager.shared.verifyRecoveryCode(
+                    email: email.trimmingCharacters(in: .whitespaces),
+                    code: code.trimmingCharacters(in: .whitespaces)
+                )
+                step = .done
+            } catch {
+                errorMessage = "That code didn't work. Check it and try again, or request a new one."
+                print("[Account] verify recovery code error: \(error)")
+            }
+            isWorking = false
+        }
+    }
+}

--- a/DailyTracker/Views/Friends/FriendsView.swift
+++ b/DailyTracker/Views/Friends/FriendsView.swift
@@ -52,10 +52,10 @@ struct FriendsView: View {
             .sheet(isPresented: $showingRecovery) {
                 RecoverAccountView()
             }
-            .task { await vm.load() }
-            .onChange(of: SupabaseManager.shared.userId) { _, _ in
-                // Reload profile & friends after an account recovery.
-                Task { await vm.load() }
+            .task(id: SupabaseManager.shared.userId) {
+                // Re-runs (cancelling any in-flight load) after an account
+                // recovery changes the signed-in user.
+                await vm.load()
             }
         }
     }

--- a/DailyTracker/Views/Friends/FriendsView.swift
+++ b/DailyTracker/Views/Friends/FriendsView.swift
@@ -8,6 +8,8 @@ struct FriendsView: View {
     @State private var addError: String? = nil
     @State private var editingName = false
     @State private var nameInput = ""
+    @State private var showingLinkEmail = false
+    @State private var showingRecovery = false
 
     @Environment(\.dismiss) private var dismiss
 
@@ -22,6 +24,8 @@ struct FriendsView: View {
                 }
 
                 friendsSection
+
+                accountSection
 
                 aboutSection
             }
@@ -42,7 +46,17 @@ struct FriendsView: View {
             .sheet(item: $selectedFriend) { friend in
                 FriendCalendarView(friend: friend, vm: vm)
             }
+            .sheet(isPresented: $showingLinkEmail) {
+                LinkEmailView()
+            }
+            .sheet(isPresented: $showingRecovery) {
+                RecoverAccountView()
+            }
             .task { await vm.load() }
+            .onChange(of: SupabaseManager.shared.userId) { _, _ in
+                // Reload profile & friends after an account recovery.
+                Task { await vm.load() }
+            }
         }
     }
 
@@ -176,6 +190,31 @@ struct FriendsView: View {
                     .controlSize(.small)
                 }
             }
+        }
+    }
+
+    // MARK: - Account Section
+
+    private var accountSection: some View {
+        Section {
+            HStack {
+                Text("Email")
+                Spacer()
+                Text(SupabaseManager.shared.linkedEmail ?? "Not linked")
+                    .foregroundStyle(.secondary)
+            }
+            if SupabaseManager.shared.linkedEmail == nil {
+                Button("Link Email to Protect Account") {
+                    showingLinkEmail = true
+                }
+            }
+            Button("Recover Account…") {
+                showingRecovery = true
+            }
+        } header: {
+            Text("Account")
+        } footer: {
+            Text("Linking an email lets you recover your account and data if you're ever signed out — after a reinstall, on a new phone, or if sign-in fails.")
         }
     }
 

--- a/docs/ACCOUNT_RECOVERY.md
+++ b/docs/ACCOUNT_RECOVERY.md
@@ -1,0 +1,96 @@
+# Recovering an orphaned account
+
+## Background
+
+Before the fix in this branch, a failed session load on launch (e.g. a token
+refresh attempted right after a device reboot, before the network was up)
+caused the app to create a **new** anonymous Supabase user. The old account —
+and every `task_items`, `day_records`, `profiles`, and `friendships` row tied
+to it — still exists in the database, but Row Level Security hides it from the
+new user, so the app looks empty.
+
+There are two ways back. **Path A recovers the old account itself** (keeps the
+same user ID, so friendships keep working in both directions) and is the
+recommended one. Path B copies the data to the new account instead.
+
+Both paths need the Supabase **service role key** (Dashboard → Project
+Settings → API). Never ship or commit that key.
+
+## Step 0 — Identify the old user ID
+
+Run this in the Supabase SQL editor:
+
+```sql
+select
+  u.id,
+  u.created_at,
+  u.last_sign_in_at,
+  u.email,
+  (select count(*) from public.task_items  t where t.user_id = u.id) as task_count,
+  (select count(*) from public.day_records d where d.user_id = u.id) as day_count,
+  (select p.display_name from public.profiles p where p.user_id = u.id) as display_name
+from auth.users u
+order by u.created_at;
+```
+
+The **old** account is the one with your task/day counts and display name and
+an older `created_at`. The **new** (accidental) account was created the day of
+the reboot and has little or no data. The old ID also matches the `userId`
+stored on the device's local records.
+
+## Path A (recommended): recover the old account via email
+
+1. **Attach your email to the old user** with the admin API (one-time, run
+   from your machine — replace placeholders):
+
+   ```bash
+   curl -X PUT "https://bchsgwwlqojfbnrcyqem.supabase.co/auth/v1/admin/users/<OLD_USER_ID>" \
+     -H "apikey: <SERVICE_ROLE_KEY>" \
+     -H "Authorization: Bearer <SERVICE_ROLE_KEY>" \
+     -H "Content-Type: application/json" \
+     -d '{"email": "<your-email>", "email_confirm": true}'
+   ```
+
+2. **Make sure sign-in codes appear in emails.** Dashboard → Authentication →
+   Email Templates → *Magic Link*: the body must contain `{{ .Token }}`
+   (the 6-digit code), e.g.
+
+   ```html
+   <p>Your sign-in code is: {{ .Token }}</p>
+   ```
+
+3. **In the app** (a build with this branch): open the Friends screen
+   (person icon) → **Account** → **Recover Account…** → enter the email →
+   enter the emailed code. The app switches back to the old user ID; local
+   data is rebound automatically and anything missing locally is pulled down
+   from the database. Friendships work again immediately because the user ID
+   is unchanged.
+
+4. **Optional cleanup:** delete the accidental new user in Dashboard →
+   Authentication → Users. Do this only *after* recovery has completed on the
+   device — deleting the user cascade-deletes its rows.
+
+Going forward, every user can pre-empt this entirely: **Account → Link Email
+to Protect Account** attaches an email to the anonymous account, making it
+recoverable on any device.
+
+## Path B (fallback): reassign the data to the new account
+
+If you'd rather keep the new account, run
+`supabase/scripts/reassign_user_data.sql` in the SQL editor after filling in
+the old and new user IDs. Note that friends would then see you under a new
+user ID, and the old account can be deleted afterwards.
+
+## What the app-side fix changed
+
+- A session-load failure no longer creates a new anonymous account; the app
+  falls back to the stored session or the cached user ID, and only signs in
+  anonymously on a true first launch.
+- Accounts can be protected with a linked email and recovered with a one-time
+  emailed code (Friends screen → Account).
+- The app can now *read* its data back from Supabase (it previously only
+  wrote), so a recovered or freshly-installed device restores tasks and
+  calendar history from the database.
+- Local data stored under a stale user ID is automatically rebound to the
+  current account, with duplicate tasks (by title) and day records (by date)
+  merged.

--- a/supabase/scripts/reassign_user_data.sql
+++ b/supabase/scripts/reassign_user_data.sql
@@ -1,0 +1,53 @@
+-- Reassigns all DailyTracker data from one user to another.
+-- Fallback recovery path (Path B in docs/ACCOUNT_RECOVERY.md): use when the
+-- old account itself is not being recovered and its data should move to the
+-- account currently on the device.
+--
+-- Run in the Supabase SQL editor. Replace the two UUIDs below first.
+-- See docs/ACCOUNT_RECOVERY.md Step 0 for how to identify them.
+
+do $$
+declare
+  old_user uuid := '00000000-0000-0000-0000-000000000000';  -- account that owns the data
+  new_user uuid := '11111111-1111-1111-1111-111111111111';  -- account on the device now
+begin
+  if not exists (select 1 from auth.users where id = old_user) then
+    raise exception 'old_user % not found in auth.users', old_user;
+  end if;
+  if not exists (select 1 from auth.users where id = new_user) then
+    raise exception 'new_user % not found in auth.users', new_user;
+  end if;
+
+  update public.task_items set user_id = new_user where user_id = old_user;
+
+  -- The new account may have created day records since the incident (unique
+  -- on user_id + date_string). Keep the old account's richer record for any
+  -- clashing date by removing the new account's copy first.
+  delete from public.day_records
+  where user_id = new_user
+    and date_string in (
+      select date_string from public.day_records where user_id = old_user
+    );
+  update public.day_records set user_id = new_user where user_id = old_user;
+
+  -- profiles is keyed by user_id; keep the old profile (name, friend code).
+  delete from public.profiles where user_id = new_user;
+  update public.profiles set user_id = new_user where user_id = old_user;
+
+  -- Move friendships, skipping any that would collide with ones the new
+  -- account already has.
+  update public.friendships f set requester_id = new_user
+  where f.requester_id = old_user
+    and not exists (
+      select 1 from public.friendships x
+      where x.requester_id = new_user and x.addressee_id = f.addressee_id
+    );
+  update public.friendships f set addressee_id = new_user
+  where f.addressee_id = old_user
+    and not exists (
+      select 1 from public.friendships x
+      where x.requester_id = f.requester_id and x.addressee_id = new_user
+    );
+  -- Remove any leftovers that collided.
+  delete from public.friendships where requester_id = old_user or addressee_id = old_user;
+end $$;

--- a/supabase/scripts/reassign_user_data.sql
+++ b/supabase/scripts/reassign_user_data.sql
@@ -30,23 +30,39 @@ begin
     );
   update public.day_records set user_id = new_user where user_id = old_user;
 
-  -- profiles is keyed by user_id; keep the old profile (name, friend code).
-  delete from public.profiles where user_id = new_user;
-  update public.profiles set user_id = new_user where user_id = old_user;
+  -- profiles is keyed by user_id; keep the old profile (name, friend code) —
+  -- but only if the old account actually has one. The old anonymous user may
+  -- never have opened the Friends screen (profiles are created lazily), and
+  -- unconditionally deleting the new account's profile would strand it with
+  -- no row and an unrecoverable friend_code.
+  if exists (select 1 from public.profiles where user_id = old_user) then
+    delete from public.profiles where user_id = new_user;
+    update public.profiles set user_id = new_user where user_id = old_user;
+  end if;
 
-  -- Move friendships, skipping any that would collide with ones the new
-  -- account already has.
+  -- Merging two accounts that were already friends with each other would
+  -- otherwise turn into a self-friendship; drop that relationship instead.
+  delete from public.friendships
+  where (requester_id = old_user and addressee_id = new_user)
+     or (requester_id = new_user and addressee_id = old_user);
+
+  -- Move the remaining friendships, skipping any that would duplicate a
+  -- friendship the new account already has with the same person — checked in
+  -- BOTH directions, since the app treats an accepted friendship as
+  -- undirected and add_friend_by_code blocks requests either way.
   update public.friendships f set requester_id = new_user
   where f.requester_id = old_user
     and not exists (
       select 1 from public.friendships x
-      where x.requester_id = new_user and x.addressee_id = f.addressee_id
+      where (x.requester_id = new_user and x.addressee_id = f.addressee_id)
+         or (x.requester_id = f.addressee_id and x.addressee_id = new_user)
     );
   update public.friendships f set addressee_id = new_user
   where f.addressee_id = old_user
     and not exists (
       select 1 from public.friendships x
-      where x.requester_id = f.requester_id and x.addressee_id = new_user
+      where (x.requester_id = new_user and x.addressee_id = f.requester_id)
+         or (x.requester_id = f.requester_id and x.addressee_id = new_user)
     );
   -- Remove any leftovers that collided.
   delete from public.friendships where requester_id = old_user or addressee_id = old_user;


### PR DESCRIPTION
## Summary

This PR adds account recovery and data restoration capabilities to DailyTracker, fixing a critical issue where failed session loads could orphan user accounts and data. Users can now protect their anonymous accounts by linking an email, and recover them on any device using a one-time code. The app can also restore tasks and calendar history from the cloud when needed.

## Key Changes

- **Account Recovery UI** (`AccountRecoveryViews.swift`): Two new views enable users to link an email to their account and recover an existing account using a one-time code sent via email.

- **Enhanced Auth Flow** (`SupabaseManager.swift`): 
  - Improved session loading to fall back to cached user ID instead of creating a new anonymous account on transient failures
  - Added email linking via `linkEmail()`
  - Added recovery code flow: `sendRecoveryCode()` and `verifyRecoveryCode()`
  - Added cloud read path with `fetchRemoteTasks()` and `fetchRemoteDayRecords()` to restore data from Supabase

- **Data Restoration** (`ContentView.swift`):
  - New `restoreFromCloudIfNeeded()` method pulls tasks and day records from the server after account recovery or on fresh installs
  - New `adoptOrphanedData()` method rebinds local data stored under stale user IDs to the current account, with intelligent merging of duplicates by title/date
  - Replaced `onChange` with `task(id:)` for more reliable user ID tracking

- **Friends UI Integration** (`FriendsView.swift`): Added Account section showing linked email status with buttons to link email or recover account.

- **Root View Refactor** (`DailyTrackerApp.swift`): Extracted `RootView` to properly bridge observable auth state into the view tree, ensuring UI updates when the signed-in user changes.

- **Documentation & Recovery Scripts** (`docs/ACCOUNT_RECOVERY.md`, `supabase/scripts/reassign_user_data.sql`): Comprehensive guide for recovering orphaned accounts with two paths (recover old account via email or reassign data to new account).

## Notable Implementation Details

- Session load failures no longer create new anonymous accounts; the app preserves the known user identity and only creates a new account on true first launch
- Cloud restore is triggered by a flag (`needsCloudRestore`) set during account recovery, or automatically when local data is empty
- Data merging handles duplicates intelligently: tasks are deduplicated by title, day records by date, with task completion states merged
- The `@Observable` macro on `SupabaseManager` enables reactive UI updates when auth state changes

https://claude.ai/code/session_01AJ4FfjzS2EvRL2VNVdd6TE